### PR TITLE
Update GeneSetScoringTables.java

### DIFF
--- a/src/edu/mit/broad/genome/alg/gsea/GeneSetScoringTables.java
+++ b/src/edu/mit/broad/genome/alg/gsea/GeneSetScoringTables.java
@@ -182,11 +182,7 @@ public class GeneSetScoringTables {
 
             score = _abs(score);
 
-            if (XMath.isPositive(score)) {
-                return score / totalWeight;
-            } else {
-                return score / totalWeight;
-            }
+            return score / totalWeight;
         }
 
         // misses are not weighted


### PR DESCRIPTION
The sign check in `getHitScore` seems to be redundant as `_abs()` is called on score earlier and the if/else blocks have exactly the same code.