### PR TITLE
Bug-fixes: Collapse with remapping; Chip FTP failure; JNLP launch

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -98,11 +98,13 @@ task fullJar(type: Jar, dependsOn: jar) {
     }
 }
 
-task optimizeJar(type: proguard.gradle.ProGuardTask, dependsOn: fullJar) {
+task optimizeJar(type: proguard.gradle.ProGuardTask, dependsOn: jar) {
     doFirst { mkdir "proguard_log" }
     
     verbose
-    injars "${buildDir}/libs/gsea-all_deps-${version}.jar"
+    injars "${buildDir}/libs/gsea-minimal-${version}.jar"
+    injars "modules", jarfilter: "!" + configurations.jarsToShipUntouched.collect { it.getName() }.join(',!'), filter: '!META-INF/**'
+    injars "lib", filter: '!META-INF/**'
     outjars "${buildDir}/libs/gsea-${version}.jar"
 
     // Automatically handle the Java version of this build.

--- a/lib_build/proguard_opt.cfg
+++ b/lib_build/proguard_opt.cfg
@@ -29,9 +29,8 @@
 }
 
 # Also keep - Key JIDE items: the app will not run if these classes are altered by ProGuard
--keepclasseswithmembers,includedescriptorclasses class com.jidesoft.utils.**,com.jidesoft.plaf.** {
-    <fields>;
-    <methods>;
+-keep,includedescriptorclasses class com.jidesoft.utils.**,com.jidesoft.plaf.** {
+    *;
 }
 
 # Also keep - Key jfreechart items formerly kept by jShrink

--- a/src/main/java/edu/mit/broad/genome/alg/DatasetGenerators.java
+++ b/src/main/java/edu/mit/broad/genome/alg/DatasetGenerators.java
@@ -119,24 +119,16 @@ public class DatasetGenerators {
             String symbol = chip.getSymbol(ps, nm);
             String title = chip.getTitle(ps, nm);
 
-            if (symbol != null && includeOnlySymbols && ps.equals(symbol)) {
-                // chip returned a matching symbol, we include only symbols, but that
-                // symbol is equal to the probe id
-                // @todo hack as the symbol lookup isn't always removed
-            } else {
-
-                if (symbol != null) {
-                    Object obj = symbolStrucMap.get(symbol);
-                    if (obj == null) {
-                        // Note: we only save the *first* title, so if they differ the subsequent
-                        // ones are ignored.
-                        obj = new CollapseStruc(symbol, title);
-                    }
-                    ((CollapseStruc) obj).add(ps);
-                    symbolStrucMap.put(symbol, obj);
+            if (symbol != null) {
+                Object obj = symbolStrucMap.get(symbol);
+                if (obj == null) {
+                    // Note: we only save the *first* title, so if they differ the subsequent
+                    // ones are ignored.
+                    obj = new CollapseStruc(symbol, title);
                 }
+                ((CollapseStruc) obj).add(ps);
+                symbolStrucMap.put(symbol, obj);
             }
-
         }
 
         // symbolStructMap is a mapping of present symbol names to CollapseStruc objects, where

--- a/src/main/java/xtools/api/param/ChipOptParam.java
+++ b/src/main/java/xtools/api/param/ChipOptParam.java
@@ -206,7 +206,7 @@ public class ChipOptParam extends AbstractParam {
                 setIcon(null);
             }
 
-            if (str.contains(ComparatorFactory.ChipNameComparator.getHighestVersionId())) {
+            if (!skipRenderCheck && str.contains(ComparatorFactory.ChipNameComparator.getHighestVersionId())) {
                 Font font = this.getFont();
                 String fontName = font.getFontName();
                 int fontSize = font.getSize();


### PR DESCRIPTION
Removed special-case code that prevented Collapse Dataset from remapping
a symbol onto itself.  Fixes #14 
Fixed error handling for when the Chip chooser can't reach the FTP site.
Adjusted the Java 8 jar optimization to include some missing classes
needed for the JNLP launch.